### PR TITLE
run_on_slaves: plugin orginally did not run on slaves.

### DIFF
--- a/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/ProjectResultBuildAction.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/ProjectResultBuildAction.java
@@ -1,5 +1,6 @@
 package com.cwctravel.hudson.plugins.multimoduletests;
 
+import hudson.FilePath;
 import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
 import hudson.tasks.junit.TestAction;
@@ -12,6 +13,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
 
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerProxy;
@@ -109,7 +112,7 @@ public class ProjectResultBuildAction extends AbstractTestResultAction<ProjectRe
 		if(summary == null) {
 			JUnitDB junitDB;
 			try {
-				junitDB = new JUnitDB(owner.getProject().getRootDir().getAbsolutePath());
+				junitDB = new JUnitDB(new FilePath(Jenkins.getInstance().getChannel(), owner.getProject().getRootDir().getAbsolutePath()));
 				summary = junitDB.fetchTestProjectSummaryForBuild(owner.getNumber(), owner.getProject().getName());
 			}
 			catch(SQLException e) {

--- a/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/ProjectResultProjectAction.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/ProjectResultProjectAction.java
@@ -1,5 +1,6 @@
 package com.cwctravel.hudson.plugins.multimoduletests;
 
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.tasks.test.TestResultProjectAction;
@@ -10,6 +11,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
 
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.Stapler;
@@ -97,7 +100,7 @@ public class ProjectResultProjectAction extends TestResultProjectAction implemen
 					AbstractProject<?, ?> project = projectResult.getOwner().getParent();
 					JUnitDB junitDB;
 					try {
-						junitDB = new JUnitDB(project.getRootDir().getAbsolutePath());
+						junitDB = new JUnitDB(new FilePath(Jenkins.getInstance().getChannel(), project.getRootDir().getAbsolutePath()));
 						List<JUnitSummaryInfo> historyList = junitDB.fetchTestModuleSummaryHistory(project.getName(), moduleName, MAX_HISTORY);
 						return new TrendGraph("/testReport/", "/" + moduleName + "/", "count", historyList);
 					}

--- a/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/ProjectResultPublisher.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/ProjectResultPublisher.java
@@ -2,6 +2,7 @@ package com.cwctravel.hudson.plugins.multimoduletests;
 
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.model.Action;
@@ -31,6 +32,7 @@ import java.util.logging.Logger;
 import javax.xml.parsers.ParserConfigurationException;
 
 import jenkins.MasterToSlaveFileCallable;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
 import org.apache.tools.ant.DirectoryScanner;
@@ -102,7 +104,7 @@ public class ProjectResultPublisher extends Recorder implements Serializable {
 		final long buildTime = build.getTimestamp().getTimeInMillis();
 		final long nowMaster = System.currentTimeMillis();
 
-		File junitDBDir = build.getProject().getRootDir();
+		String junitDBDir = build.getProject().getRootDir().toString();
 		String testResultFileMask = Util.replaceMacro(config.getTestResultFileMask(), build.getBuildVariableResolver());
 
 		List<String> activeBuildIds = new ArrayList<String>();
@@ -180,9 +182,9 @@ public class ProjectResultPublisher extends Recorder implements Serializable {
 		private final List<String> moduleNames;
 		private final List<String> activeBuildIds;
 
-		private final File junitDBDir;
+		private final FilePath junitDBDir;
 
-		private ParseResultCallable(File junitDBDir, String buildId, int buildNumber, String projectName, String moduleNamesStr,
+		private ParseResultCallable(String junitDBDir, String buildId, int buildNumber, String projectName, String moduleNamesStr,
 				List<String> activeBuildIds, String testResults, long buildTime, long nowMaster, boolean keepLongStdio) {
 			this.buildId = buildId;
 			this.buildNumber = buildNumber;
@@ -193,7 +195,7 @@ public class ProjectResultPublisher extends Recorder implements Serializable {
 
 			this.keepLongStdio = keepLongStdio;
 
-			this.junitDBDir = junitDBDir;
+			this.junitDBDir = new FilePath(Jenkins.getInstance().getChannel(), junitDBDir);
 
 			this.moduleNames = new ArrayList<String>();
 			if(moduleNamesStr != null) {
@@ -220,7 +222,7 @@ public class ProjectResultPublisher extends Recorder implements Serializable {
 			File baseDir = ds.getBasedir();
 
 			try {
-				JUnitDB junitDB = new JUnitDB(junitDBDir.getAbsolutePath());
+				JUnitDB junitDB = new JUnitDB(junitDBDir);
 				junitDB.compactDB(projectName, activeBuildIds);
 
 				JUnitParser junitParser = new JUnitParser(junitDB);

--- a/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/CaseResult.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/CaseResult.java
@@ -24,6 +24,7 @@
 package com.cwctravel.hudson.plugins.multimoduletests.junit;
 
 import static java.util.Collections.emptyList;
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.tasks.junit.TestAction;
@@ -40,6 +41,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
 
 import org.jvnet.localizer.Localizable;
 import org.kohsuke.stapler.export.Exported;
@@ -77,7 +80,7 @@ public final class CaseResult extends TestResult implements Comparable<CaseResul
 		this.parent = parent;
 		this.testInfo = testInfo;
 		try {
-			this.junitDB = new JUnitDB(getOwner().getProject().getRootDir().getAbsolutePath());
+			this.junitDB = new JUnitDB(new FilePath(Jenkins.getInstance().getChannel(), getOwner().getProject().getRootDir().getAbsolutePath()));
 		}
 		catch(SQLException sE) {
 			throw new JUnitException(sE);

--- a/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/ClassResult.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/ClassResult.java
@@ -23,6 +23,7 @@
  */
 package com.cwctravel.hudson.plugins.multimoduletests.junit;
 
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.tasks.junit.TestAction;
@@ -36,6 +37,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
 
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -72,7 +75,7 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
 		this.parent = parent;
 		this.summary = summary;
 		try {
-			junitDB = new JUnitDB(getOwner().getProject().getRootDir().getAbsolutePath());
+			junitDB = new JUnitDB(new FilePath(Jenkins.getInstance().getChannel(), getOwner().getProject().getRootDir().getAbsolutePath()));
 		}
 		catch(SQLException sE) {
 			throw new JUnitException(sE);
@@ -146,8 +149,7 @@ public final class ClassResult extends TabulatedResult implements Comparable<Cla
 			return className.substring(idx + 1);
 	}
 
-	public @Override
-	String getSafeName() {
+	public @Override String getSafeName() {
 		return safe(getName());
 	}
 

--- a/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/History.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/History.java
@@ -23,6 +23,7 @@
  */
 package com.cwctravel.hudson.plugins.multimoduletests.junit;
 
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Hudson;
@@ -41,6 +42,8 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
 
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
@@ -74,7 +77,7 @@ public class History extends hudson.tasks.junit.History {
 		try {
 			AbstractProject<?, ?> project = testObject.getOwner().getParent();
 			String projectName = project.getName();
-			JUnitDB junitDB = new JUnitDB(project.getRootDir().getAbsolutePath());
+			JUnitDB junitDB = new JUnitDB(new FilePath(Jenkins.getInstance().getChannel(), project.getRootDir().getAbsolutePath()));
 			if(testObject instanceof ProjectResult) {
 				historyItems = junitDB.summarizeTestProjectHistory(projectName, limit);
 			}

--- a/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/ModuleResult.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/ModuleResult.java
@@ -23,6 +23,7 @@
  */
 package com.cwctravel.hudson.plugins.multimoduletests.junit;
 
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.tasks.junit.TestAction;
@@ -40,6 +41,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
 
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -86,7 +89,7 @@ public final class ModuleResult extends MetaTabulatedResult {
 		this.parent = parent;
 		this.summary = junitSummaryInfo;
 		try {
-			this.junitDB = new JUnitDB(getOwner().getProject().getRootDir().getAbsolutePath());
+			this.junitDB = new JUnitDB(new FilePath(Jenkins.getInstance().getChannel(), getOwner().getProject().getRootDir().getAbsolutePath()));
 		}
 		catch(SQLException sE) {
 			throw new JUnitException(sE);

--- a/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/PackageResult.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/PackageResult.java
@@ -23,6 +23,7 @@
  */
 package com.cwctravel.hudson.plugins.multimoduletests.junit;
 
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.tasks.junit.TestAction;
@@ -37,6 +38,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
 
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -74,7 +77,7 @@ public final class PackageResult extends MetaTabulatedResult implements Comparab
 		this.parent = parent;
 		this.summary = summary;
 		try {
-			junitDB = new JUnitDB(getOwner().getProject().getRootDir().getAbsolutePath());
+			junitDB = new JUnitDB(new FilePath(Jenkins.getInstance().getChannel(), getOwner().getProject().getRootDir().getAbsolutePath()));
 		}
 		catch(SQLException sE) {
 			throw new JUnitException(sE);

--- a/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/ProjectResult.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/ProjectResult.java
@@ -1,5 +1,6 @@
 package com.cwctravel.hudson.plugins.multimoduletests.junit;
 
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Run;
@@ -18,6 +19,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
 
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -65,7 +68,7 @@ public class ProjectResult extends MetaTabulatedResult {
 	public ProjectResult(AbstractProject<?, ?> project, JUnitSummaryInfo summary, String moduleNamesStr, String description) {
 		this.description = description;
 		try {
-			this.junitDB = new JUnitDB(project.getRootDir().getAbsolutePath());
+			this.junitDB = new JUnitDB(new FilePath(Jenkins.getInstance().getChannel(), project.getRootDir().getAbsolutePath()));
 			this.summary = summary;
 			moduleNames = new ArrayList<String>();
 			if(moduleNamesStr != null) {

--- a/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/db/JUnitDB.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/db/JUnitDB.java
@@ -1,5 +1,7 @@
 package com.cwctravel.hudson.plugins.multimoduletests.junit.db;
 
+import hudson.FilePath;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
@@ -650,7 +652,7 @@ private static final String JUNIT_ACTIVE_BUILDS_TABLE_INSERT_QUERY = "INSERT INT
 //@formatter:on	
 	private static final Logger LOGGER = Logger.getLogger(JUnitDB.class.getName());
 
-	private final String databaseDir;
+	private final FilePath databaseDir;
 
 	private String getDatabasePath() {
 		return databaseDir + "/JUnitDB";
@@ -763,7 +765,7 @@ private static final String JUNIT_ACTIVE_BUILDS_TABLE_INSERT_QUERY = "INSERT INT
 		return false;
 	}
 
-	public JUnitDB(String databaseDir) throws SQLException {
+	public JUnitDB(FilePath databaseDir) throws SQLException {
 		this.databaseDir = databaseDir;
 		initDB();
 	}


### PR DESCRIPTION
run_on_slaves: plugin orginally did not run on slaves. Allow the JUnit DB to be created on master, so there is no read/write access issues from the slave(s).