### PR TITLE
Increase jUnit DB size

### DIFF
--- a/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/db/JUnitDB.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/db/JUnitDB.java
@@ -532,16 +532,16 @@ public class JUnitDB {
 																							  "PROJECT_NAME VARCHAR(256) NOT NULL, " +
 																							  "BUILD_ID VARCHAR(256) NOT NULL, " +
 																							  "BUILD_NUMBER INTEGER NOT NULL, " +
-																							  "MODULE_NAME VARCHAR(256) NOT NULL, " +
-																							  "PACKAGE_NAME VARCHAR(256) NOT NULL, " +
-																							  "CLASS_NAME VARCHAR(512) NOT NULL, " +
-																							  "CASE_NAME VARCHAR(256) NOT NULL, " +
+																							  "MODULE_NAME VARCHAR(2048) NOT NULL, " +
+																							  "PACKAGE_NAME VARCHAR(4096) NOT NULL, " +
+																							  "CLASS_NAME VARCHAR(2048) NOT NULL, " +
+																							  "CASE_NAME VARCHAR(2048) NOT NULL, " +
 																							  "INDEX INT, " +
 																							  "STATUS INT, " +
 																							  "START_TIME TIMESTAMP, " +
 																							  "DURATION BIGINT, " +
-																							  "ERROR_MESSAGE VARCHAR(1024), " +
-																							  "ERROR_STACK_TRACE VARCHAR(8192), " +
+																							  "ERROR_MESSAGE VARCHAR(8192), " +
+																							  "ERROR_STACK_TRACE VARCHAR(524288), " +
 																							  "STDOUT CLOB(64 M), " + 
 																							  "STDERR CLOB(64 M) " + 
 																							 ")";
@@ -565,7 +565,7 @@ public class JUnitDB {
 						  "PROJECT_NAME VARCHAR(256) NOT NULL, " +
 						  "BUILD_ID VARCHAR(256) NOT NULL, " +
 						  "BUILD_NUMBER INTEGER NOT NULL, " +
-						  "MODULE_NAME VARCHAR(256) NOT NULL, " +
+						  "MODULE_NAME VARCHAR(2048) NOT NULL, " +
 						  "TOTAL_COUNT BIGINT NOT NULL, " +
 						  "PASS_COUNT BIGINT NOT NULL, " +
 						  "FAIL_COUNT BIGINT NOT NULL, " +
@@ -580,8 +580,8 @@ public class JUnitDB {
 						  "PROJECT_NAME VARCHAR(256) NOT NULL, " +
 						  "BUILD_ID VARCHAR(256) NOT NULL, " +
 						  "BUILD_NUMBER INTEGER NOT NULL, " +
-						  "MODULE_NAME VARCHAR(256) NOT NULL, " +
-						  "PACKAGE_NAME VARCHAR(256) NOT NULL, " +
+						  "MODULE_NAME VARCHAR(2048) NOT NULL, " +
+						  "PACKAGE_NAME VARCHAR(4096) NOT NULL, " +
 						  "TOTAL_COUNT BIGINT NOT NULL, " +
 						  "PASS_COUNT BIGINT NOT NULL, " +
 						  "FAIL_COUNT BIGINT NOT NULL, " +

--- a/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/db/JUnitDB.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/db/JUnitDB.java
@@ -541,7 +541,7 @@ public class JUnitDB {
 																							  "START_TIME TIMESTAMP, " +
 																							  "DURATION BIGINT, " +
 																							  "ERROR_MESSAGE VARCHAR(8192), " +
-																							  "ERROR_STACK_TRACE VARCHAR(524288), " +
+																							  "ERROR_STACK_TRACE CLOB(2 M), " +
 																							  "STDOUT CLOB(64 M), " + 
 																							  "STDERR CLOB(64 M) " + 
 																							 ")";


### PR DESCRIPTION
Fix for problem with too small size of var fields in database

01:42:02.508 ERROR: Step ‘Publish JUnit test result report grouped by module’ aborted due to exception: 
01:42:02.508 java.io.IOException: remote file operation failed: /home/jenkins/jenkins_slave_coredb/workspace/Pipeline1.0-MergeMyBranch at hudson.remoting.Channel@40363870:FAT-pl1lxd-507876-ORCH: java.io.IOException: java.sql.SQLDataException: A truncation error was encountered trying to shrink VARCHAR '[0] DictionaryRangeItem[model: TTOM namespace: TTOM-Core nam&' to length 256.