### PR TITLE
Increase displayed size for stack trace and error message.

### DIFF
--- a/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/db/JUnitDB.java
+++ b/src/main/java/com/cwctravel/hudson/plugins/multimoduletests/junit/db/JUnitDB.java
@@ -794,8 +794,8 @@ private static final String JUNIT_ACTIVE_BUILDS_TABLE_INSERT_QUERY = "INSERT INT
 
 					JUnitTestDetailInfo junitTestDetailInfo = junitTestInfo.getDetail();
 					if(junitTestDetailInfo != null) {
-						pS.setString(12, truncate(junitTestDetailInfo.getErrorMessage(), 1024));
-						pS.setString(13, truncate(junitTestDetailInfo.getErrorStackTrace(), 8192));
+						pS.setString(12, truncate(junitTestDetailInfo.getErrorMessage(), 8192));
+						pS.setString(13, truncate(junitTestDetailInfo.getErrorStackTrace(), 2 * 1024 * 1024));
 
 						Reader stdoutReader = junitTestDetailInfo.getStdout();
 						if(stdoutReader != null) {


### PR DESCRIPTION
The Junit DB allows to store much larger starcktrace and error message values but report displays truncated values.  Sometimes it is critical to see whole stack trace log. 

This patch increases the displayed size of the error message for 8192. Stack-trace size in increased to 2 \* 1024 \* 1024. 
